### PR TITLE
fix: The window cannot be moved after scaling on Windows platform

### DIFF
--- a/lib/views/layout/appbar.dart
+++ b/lib/views/layout/appbar.dart
@@ -32,3 +32,12 @@ PreferredSizeWidget webAppbar() {
 PreferredSizeWidget mobileTabletAppbar() {
   return AppBar(title: getTitle());
 }
+
+PreferredSizeWidget mobileWindowsAppbar(){
+  return PreferredSize(
+      preferredSize: const Size.fromHeight(kToolbarHeight),
+      child: DragToMoveArea(
+          child: AppBar(title: getTitle())
+      )
+  );
+}

--- a/lib/views/layout/mobile.dart
+++ b/lib/views/layout/mobile.dart
@@ -14,6 +14,7 @@ class MobileLayoutView extends StatelessWidget {
     final appbar = switch (Theme.of(context).platform) {
       TargetPlatform.android => mobileTabletAppbar(),
       TargetPlatform.iOS => mobileTabletAppbar(),
+      TargetPlatform.windows => mobileWindowsAppbar(),
       _ => mobileTabletAppbar(),
     };
     return Scaffold(


### PR DESCRIPTION
#### 问题：windows平台缩放窗口之后无法移动

![image](https://github.com/user-attachments/assets/2ea75184-edf7-4097-b39d-2fe966bd6fbc)

如图，当appBar缩放后变成下面这种之后，窗口无法移动

#### 原因：
![image](https://github.com/user-attachments/assets/9f488659-97c5-4109-8eae-f595c0c78fa8)

![image](https://github.com/user-attachments/assets/d346e6b1-fe1f-4ca7-b073-2b63321794b4)

因为ScreenTypeLayout是根据窗口宽度进行样式调整，导致虽然是桌面平台但是因为缩放原因调整为了手机样式

![image](https://github.com/user-attachments/assets/c5a9fd2d-500a-4a11-b472-5d91070d8e9b)

缩放之后通过debug查看得到，进入手机样式之后，平台判断方法中得到的平台虽然是windows，但是AppBar走的是默认逻辑还是mobileTabletAppbar，即AppBar

#### 解决方法：mobile中添加平台判断
使用windowCaption中同样的逻辑，添加DragToMoveArea组件套在AppBar外层，测试之后缩放也可以移动了，且不会影响原本移动平台逻辑

https://github.com/user-attachments/assets/d10b0bdf-90f6-4e92-aa58-81920ecc2f01